### PR TITLE
Fix rack.input nil (rack > 3.0)

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -45,6 +45,8 @@ module RspecApiDocumentation
 
     def read_request_body
       input = last_request.env["rack.input"]
+      return if input.nil?
+
       input.rewind
       input.read
     end


### PR DESCRIPTION
## Context/Change

The gem is used in [suitedashboardapi](https://github.com/tourlane/suitedashboardapi/blob/main/Gemfile#L38) and is causing [builds to fail](https://github.com/tourlane/suitedashboardapi/actions/runs/10038954714/job/27741940919?pr=514) due to a fix in rack. This merge adds the fix to rspec_api_documentation gem.

