### PR TITLE
[FIX] Use ruby idiomatic method

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -64,7 +64,7 @@ module RspecApiDocumentation
 
       request_metadata[:request_method] = method
       request_metadata[:request_path] = path
-      request_metadata[:request_body] = request_body.blank? ? nil : request_body.force_encoding("UTF-8")
+      request_metadata[:request_body] = (request_body.nil? || request_body.empty?) ? nil : request_body.force_encoding("UTF-8")
       request_metadata[:request_headers] = request_headers
       request_metadata[:request_query_parameters] = query_hash
       request_metadata[:request_content_type] = request_content_type


### PR DESCRIPTION
https://github.com/tourlane/rspec_api_documentation/pull/2 This PR fixed an error using blank? but @haffla correctly pointed that blank? will only work for apps based on Rails. To make it ruby idiomatic, this PR replaces it with using combination of nil? and empty?